### PR TITLE
refactor: Create settings state in initialization

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -17,7 +17,7 @@
             "label": "Run codegen",
             "type": "shell",
             "command": [
-                "dart run build_runner build --delete-conflicting-outputs"
+                "fvm dart run build_runner build --delete-conflicting-outputs"
             ],
             "group": {
                 "kind": "none",

--- a/lib/src/feature/app/widget/app.dart
+++ b/lib/src/feature/app/widget/app.dart
@@ -25,7 +25,10 @@ class App extends StatelessWidget {
         bundle: SentryAssetBundle(),
         child: DependenciesScope(
           dependencies: result.dependencies,
-          child: const SettingsScope(child: MaterialContext()),
+          child: SettingsScope(
+            settingsBloc: result.dependencies.settingsBloc,
+            child: const MaterialContext(),
+          ),
         ),
       );
 }

--- a/lib/src/feature/initialization/model/dependencies.dart
+++ b/lib/src/feature/initialization/model/dependencies.dart
@@ -1,4 +1,5 @@
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sizzle_starter/src/feature/settings/bloc/settings_bloc.dart';
 import 'package:sizzle_starter/src/feature/settings/data/settings_repository.dart';
 
 /// {@template dependencies}
@@ -8,11 +9,14 @@ base class Dependencies {
   /// {@macro dependencies}
   Dependencies();
 
-  /// Shared preferences
+  /// [SharedPreferences] instance, used to store Key-Value pairs.
   late final SharedPreferences sharedPreferences;
 
-  /// Theme repository
+  /// [SettingsRepository] instance, used to manage theme and locale.
   late final SettingsRepository settingsRepository;
+
+  /// [SettingsBloc] instance, used to manage theme and locale.
+  late final SettingsBloc settingsBloc;
 }
 
 /// {@template initialization_result}

--- a/lib/src/feature/settings/bloc/settings_bloc.dart
+++ b/lib/src/feature/settings/bloc/settings_bloc.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart' show Locale;
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:sizzle_starter/src/core/localization/localization.dart';
 import 'package:sizzle_starter/src/feature/app/model/app_theme.dart';
 import 'package:sizzle_starter/src/feature/settings/data/settings_repository.dart';
 
@@ -15,31 +14,31 @@ sealed class SettingsState with _$SettingsState {
   /// Idle state for the [SettingsBloc].
   const factory SettingsState.idle({
     /// The current locale.
-    required Locale locale,
+    Locale? locale,
 
     /// The current theme mode.
-    required AppTheme appTheme,
+    AppTheme? appTheme,
   }) = _IdleSettingsState;
 
   /// Processing state for the [SettingsBloc].
   const factory SettingsState.processing({
     /// The current locale.
-    required Locale locale,
+    Locale? locale,
 
     /// The current theme mode.
-    required AppTheme appTheme,
+    AppTheme? appTheme,
   }) = _ProcessingSettingsState;
 
   /// Error state for the [SettingsBloc].
   const factory SettingsState.error({
+    /// The error message.
+    required Object cause,
+
     /// The current locale.
-    required Locale locale,
+    Locale? locale,
 
     /// The current theme mode.
-    required AppTheme appTheme,
-
-    /// The error message.
-    required String message,
+    AppTheme? appTheme,
   }) = _ErrorSettingsState;
 }
 
@@ -66,15 +65,11 @@ sealed class SettingsEvent with _$SettingsEvent {
 /// {@endtemplate}
 final class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
   /// {@macro settings_bloc}
-  SettingsBloc(this._settingsRepository)
-      : super(
-          SettingsState.idle(
-            appTheme: _settingsRepository.fetchThemeFromCache() ??
-                AppTheme.defaultTheme,
-            locale: _settingsRepository.fetchLocaleFromCache() ??
-                Localization.computeDefaultLocale(),
-          ),
-        ) {
+  SettingsBloc({
+    required SettingsRepository settingsRepository,
+    required SettingsState initialState,
+  })  : _settingsRepository = settingsRepository,
+        super(initialState) {
     on<SettingsEvent>(
       (event, emit) => event.map(
         updateTheme: (event) => _updateTheme(event, emit),
@@ -90,7 +85,7 @@ final class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
     Emitter<SettingsState> emitter,
   ) async {
     emitter(
-      _ProcessingSettingsState(
+      SettingsState.processing(
         appTheme: state.appTheme,
         locale: state.locale,
       ),
@@ -107,7 +102,7 @@ final class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
         SettingsState.error(
           appTheme: state.appTheme,
           locale: state.locale,
-          message: e.toString(),
+          cause: e,
         ),
       );
       rethrow;
@@ -119,7 +114,7 @@ final class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
     Emitter<SettingsState> emitter,
   ) async {
     emitter(
-      _ProcessingSettingsState(
+      SettingsState.processing(
         appTheme: state.appTheme,
         locale: state.locale,
       ),
@@ -136,7 +131,7 @@ final class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
         SettingsState.error(
           appTheme: state.appTheme,
           locale: state.locale,
-          message: e.toString(),
+          cause: e,
         ),
       );
       rethrow;

--- a/lib/src/feature/settings/data/locale_datasource.dart
+++ b/lib/src/feature/settings/data/locale_datasource.dart
@@ -12,14 +12,14 @@ abstract interface class LocaleDataSource {
   Future<void> setLocale(Locale locale);
 
   /// Get current locale from cache
-  Locale? loadLocaleFromCache();
+  Future<Locale?> getLocale();
 }
 
 /// {@macro locale_datasource}
-final class LocaleDataSourceImpl extends PreferencesDao
+final class LocaleDataSourceLocal extends PreferencesDao
     implements LocaleDataSource {
   /// {@macro locale_datasource}
-  const LocaleDataSourceImpl({required super.sharedPreferences});
+  const LocaleDataSourceLocal({required super.sharedPreferences});
 
   PreferencesEntry<String> get _locale => stringEntry('settings.locale');
 
@@ -29,7 +29,7 @@ final class LocaleDataSourceImpl extends PreferencesDao
   }
 
   @override
-  Locale? loadLocaleFromCache() {
+  Future<Locale?> getLocale() async {
     final languageCode = _locale.read();
 
     if (languageCode == null) return null;

--- a/lib/src/feature/settings/data/settings_repository.dart
+++ b/lib/src/feature/settings/data/settings_repository.dart
@@ -12,10 +12,10 @@ abstract interface class SettingsRepository {
   Future<void> setLocale(Locale locale);
 
   /// Observe theme mode changes
-  AppTheme? fetchThemeFromCache();
+  Future<AppTheme?> getTheme();
 
   /// Observe locale changes
-  Locale? fetchLocaleFromCache();
+  Future<Locale?> getLocale();
 }
 
 /// {@template settings_repository_impl}
@@ -33,10 +33,10 @@ final class SettingsRepositoryImpl implements SettingsRepository {
   final LocaleDataSource _localeDataSource;
 
   @override
-  Locale? fetchLocaleFromCache() => _localeDataSource.loadLocaleFromCache();
+  Future<Locale?> getLocale() => _localeDataSource.getLocale();
 
   @override
-  AppTheme? fetchThemeFromCache() => _themeDataSource.loadThemeFromCache();
+  Future<AppTheme?> getTheme() => _themeDataSource.getTheme();
 
   @override
   Future<void> setLocale(Locale locale) => _localeDataSource.setLocale(locale);

--- a/lib/src/feature/settings/data/theme_datasource.dart
+++ b/lib/src/feature/settings/data/theme_datasource.dart
@@ -6,7 +6,7 @@ import 'package:sizzle_starter/src/core/utils/preferences_dao.dart';
 import 'package:sizzle_starter/src/feature/app/model/app_theme.dart';
 
 /// {@template theme_datasource}
-/// [ThemeDataSource] is an entry point to the theme data layer.
+/// [ThemeDataSource] is a data source that provides theme data.
 ///
 /// This is used to set and get theme.
 /// {@endtemplate}
@@ -15,14 +15,14 @@ abstract interface class ThemeDataSource {
   Future<void> setTheme(AppTheme theme);
 
   /// Get current theme from cache
-  AppTheme? loadThemeFromCache();
+  Future<AppTheme?> getTheme();
 }
 
 /// {@macro theme_datasource}
-final class ThemeDataSourceImpl extends PreferencesDao
+final class ThemeDataSourceLocal extends PreferencesDao
     implements ThemeDataSource {
   /// {@macro theme_datasource}
-  const ThemeDataSourceImpl({
+  const ThemeDataSourceLocal({
     required super.sharedPreferences,
     required this.codec,
   });
@@ -41,7 +41,7 @@ final class ThemeDataSourceImpl extends PreferencesDao
   }
 
   @override
-  AppTheme? loadThemeFromCache() {
+  Future<AppTheme?> getTheme() async {
     final seedColor = _seedColor.read();
 
     final type = _themeMode.read();

--- a/lib/src/feature/settings/widget/settings_scope.dart
+++ b/lib/src/feature/settings/widget/settings_scope.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:sizzle_starter/src/core/localization/localization.dart';
 import 'package:sizzle_starter/src/core/utils/extensions/context_extension.dart';
 import 'package:sizzle_starter/src/feature/app/model/app_theme.dart';
-import 'package:sizzle_starter/src/feature/initialization/widget/dependencies_scope.dart';
 import 'package:sizzle_starter/src/feature/settings/bloc/settings_bloc.dart';
 
 /// {@template theme_scope_controller}
@@ -54,10 +54,17 @@ enum _SettingsScopeAspect {
 /// {@endtemplate}
 class SettingsScope extends StatefulWidget {
   /// {@macro settings_scope}
-  const SettingsScope({required this.child, super.key});
+  const SettingsScope({
+    required this.child,
+    required this.settingsBloc,
+    super.key,
+  });
 
   /// The child widget.
   final Widget child;
+
+  /// The [SettingsBloc] instance.
+  final SettingsBloc settingsBloc;
 
   /// Get the [SettingsScopeController] of the closest [SettingsScope] ancestor.
   static SettingsScopeController of(
@@ -87,55 +94,37 @@ class SettingsScope extends StatefulWidget {
 /// State for widget SettingsScope
 class _SettingsScopeState extends State<SettingsScope>
     implements SettingsScopeController {
-  late final SettingsBloc _settingsBloc;
-
-  @override
-  void initState() {
-    super.initState();
-    _settingsBloc = SettingsBloc(
-      DependenciesScope.of(context).settingsRepository,
-    );
-  }
-
-  @override
-  void dispose() {
-    _settingsBloc.close();
-    super.dispose();
-  }
-
   @override
   void setLocale(Locale locale) {
-    _settingsBloc.add(SettingsEvent.updateLocale(locale: locale));
+    widget.settingsBloc.add(SettingsEvent.updateLocale(locale: locale));
   }
 
   @override
-  void setThemeMode(ThemeMode themeMode) {
-    _settingsBloc.add(
-      SettingsEvent.updateTheme(
-        appTheme: AppTheme(mode: themeMode, seed: theme.seed),
-      ),
-    );
-  }
+  void setThemeMode(ThemeMode themeMode) => widget.settingsBloc.add(
+        SettingsEvent.updateTheme(
+          appTheme: AppTheme(mode: themeMode, seed: theme.seed),
+        ),
+      );
 
   @override
-  void setThemeSeedColor(Color color) {
-    _settingsBloc.add(
-      SettingsEvent.updateTheme(
-        appTheme: AppTheme(mode: theme.mode, seed: color),
-      ),
-    );
-  }
+  void setThemeSeedColor(Color color) => widget.settingsBloc.add(
+        SettingsEvent.updateTheme(
+          appTheme: AppTheme(mode: theme.mode, seed: color),
+        ),
+      );
 
   @override
-  Locale get locale => _settingsBloc.state.locale;
+  Locale get locale =>
+      widget.settingsBloc.state.locale ?? Localization.computeDefaultLocale();
 
   @override
-  AppTheme get theme => _settingsBloc.state.appTheme;
+  AppTheme get theme =>
+      widget.settingsBloc.state.appTheme ?? AppTheme.defaultTheme;
 
   @override
   Widget build(BuildContext context) =>
       BlocBuilder<SettingsBloc, SettingsState>(
-        bloc: _settingsBloc,
+        bloc: widget.settingsBloc,
         builder: (context, state) => _InheritedSettingsScope(
           controller: this,
           state: state,
@@ -170,8 +159,8 @@ class _InheritedSettingsScope extends InheritedModel<_SettingsScopeAspect> {
     }
 
     if (dependencies.contains(_SettingsScopeAspect.locale)) {
-      final locale = state.locale.languageCode;
-      final oldLocale = oldWidget.state.locale.languageCode;
+      final locale = state.locale?.languageCode;
+      final oldLocale = oldWidget.state.locale?.languageCode;
 
       shouldNotify = shouldNotify || locale != oldLocale;
     }


### PR DESCRIPTION
- SettingsBloc now takes a SettingsState as a parameter
- SettingsBloc is now initialized in the initialization steps which gives an opportunity for asynchronous loading
- SettingsScope now takes SettingsBloc as a parameter