### PR TITLE
Replace SharedPreferences to SharedPreferencesAsync

### DIFF
--- a/lib/src/core/rest_client/src/rest_client_base.dart
+++ b/lib/src/core/rest_client/src/rest_client_base.dart
@@ -105,7 +105,7 @@ abstract base class RestClientBase implements RestClient {
       return _jsonUTF8.encode(body);
     } on Object catch (e, stackTrace) {
       Error.throwWithStackTrace(
-        ClientException(message: 'Error occured during encoding', cause: e),
+        ClientException(message: 'Error occurred during encoding', cause: e),
         stackTrace,
       );
     }
@@ -138,7 +138,8 @@ abstract base class RestClientBase implements RestClient {
   @protected
   @visibleForTesting
   Future<Map<String, Object?>?> decodeResponse(
-    /* String, Map<String, Object?>, List<int> */ Object? body, {
+    /* String, Map<String, Object?>, List<int> */
+    Object? body, {
     int? statusCode,
   }) async {
     if (body == null) return null;

--- a/lib/src/core/utils/preferences_dao.dart
+++ b/lib/src/core/utils/preferences_dao.dart
@@ -35,8 +35,8 @@ abstract base class PreferencesDao {
         sharedPreferences: _sharedPreferences,
       );
 
-  /// Obtain `Iterable<String>` entry from the preferences.
-  PreferencesEntry<Iterable<String>> iterableStringEntry(String key) => TypedEntry<Iterable<String>>(
+  /// Obtain `List<String>` entry from the preferences.
+  PreferencesEntry<List<String>> iterableStringEntry(String key) => TypedEntry<List<String>>(
         key: key,
         sharedPreferences: _sharedPreferences,
       );
@@ -124,10 +124,7 @@ base class TypedEntry<T extends Object> extends PreferencesEntry<T> {
         final double value => _sharedPreferences.setDouble(key, value),
         final String value => _sharedPreferences.setString(key, value),
         final bool value => _sharedPreferences.setBool(key, value),
-        final List<String> value => _sharedPreferences.setStringList(
-            key,
-            value.toList(),
-          ),
+        final List<String> value => _sharedPreferences.setStringList(key, value),
         _ => throw StateError(
             '$T is not a valid type for a preferences entry value.',
           ),

--- a/lib/src/core/utils/preferences_dao.dart
+++ b/lib/src/core/utils/preferences_dao.dart
@@ -6,11 +6,10 @@ import 'package:shared_preferences/shared_preferences.dart';
 /// Inspired by https://pub.dev/packages/typed_preferences
 /// {@endtemplate}
 abstract base class PreferencesDao {
-  final SharedPreferences _sharedPreferences;
+  final SharedPreferencesAsync _sharedPreferences;
 
   /// {@macro preferences_dao}
-  const PreferencesDao({required SharedPreferences sharedPreferences})
-      : _sharedPreferences = sharedPreferences;
+  const PreferencesDao({required SharedPreferencesAsync sharedPreferences}) : _sharedPreferences = sharedPreferences;
 
   /// Obtain [bool] entry from the preferences.
   PreferencesEntry<bool> boolEntry(String key) => TypedEntry<bool>(
@@ -36,9 +35,8 @@ abstract base class PreferencesDao {
         sharedPreferences: _sharedPreferences,
       );
 
-  /// Obtain [Iterable<String>] entry from the preferences.
-  PreferencesEntry<Iterable<String>> iterableStringEntry(String key) =>
-      TypedEntry<Iterable<String>>(
+  /// Obtain `Iterable<String>` entry from the preferences.
+  PreferencesEntry<Iterable<String>> iterableStringEntry(String key) => TypedEntry<Iterable<String>>(
         key: key,
         sharedPreferences: _sharedPreferences,
       );
@@ -56,7 +54,7 @@ abstract base class PreferencesEntry<T extends Object> {
   String get key;
 
   /// Obtain the value of the entry from the preferences.
-  T? read();
+  Future<T?> read();
 
   /// Set the value of the entry in the preferences.
   Future<void> set(T value);
@@ -99,29 +97,26 @@ abstract base class PreferencesEntry<T extends Object> {
 /// ```
 /// {@endtemplate}
 base class TypedEntry<T extends Object> extends PreferencesEntry<T> {
+  final SharedPreferencesAsync _sharedPreferences;
+
   /// {@macro typed_entry}
-  TypedEntry({
-    required SharedPreferences sharedPreferences,
+  const TypedEntry({
+    required SharedPreferencesAsync sharedPreferences,
     required this.key,
   }) : _sharedPreferences = sharedPreferences;
-
-  final SharedPreferences _sharedPreferences;
 
   @override
   final String key;
 
   @override
-  T? read() {
-    final value = _sharedPreferences.get(key);
-
-    if (value == null) return null;
-
-    if (value is T) return value;
-
-    throw StateError(
-      'The value of $key is not of type $T',
-    );
-  }
+  Future<T?> read() => switch (T) {
+        const (int) => _sharedPreferences.getInt(key) as Future<T?>,
+        const (double) => _sharedPreferences.getDouble(key) as Future<T?>,
+        const (String) => _sharedPreferences.getString(key) as Future<T?>,
+        const (bool) => _sharedPreferences.getBool(key) as Future<T?>,
+        const (List<String>) => _sharedPreferences.getStringList(key) as Future<T?>,
+        _ => throw StateError('The value of $key is not of type $T'),
+      };
 
   @override
   Future<void> set(T value) => switch (value) {
@@ -129,7 +124,7 @@ base class TypedEntry<T extends Object> extends PreferencesEntry<T> {
         final double value => _sharedPreferences.setDouble(key, value),
         final String value => _sharedPreferences.setString(key, value),
         final bool value => _sharedPreferences.setBool(key, value),
-        final Iterable<String> value => _sharedPreferences.setStringList(
+        final List<String> value => _sharedPreferences.setStringList(
             key,
             value.toList(),
           ),

--- a/lib/src/core/utils/preferences_dao.dart
+++ b/lib/src/core/utils/preferences_dao.dart
@@ -9,7 +9,8 @@ abstract base class PreferencesDao {
   final SharedPreferencesAsync _sharedPreferences;
 
   /// {@macro preferences_dao}
-  const PreferencesDao({required SharedPreferencesAsync sharedPreferences}) : _sharedPreferences = sharedPreferences;
+  const PreferencesDao({required SharedPreferencesAsync sharedPreferences})
+      : _sharedPreferences = sharedPreferences;
 
   /// Obtain [bool] entry from the preferences.
   PreferencesEntry<bool> boolEntry(String key) => TypedEntry<bool>(

--- a/lib/src/feature/initialization/logic/composition_root.dart
+++ b/lib/src/feature/initialization/logic/composition_root.dart
@@ -52,7 +52,7 @@ final class CompositionRoot {
 
   Future<Dependencies> _initDependencies() async {
     final errorTrackingManager = await _initErrorTrackingManager();
-    final sharedPreferences = await SharedPreferences.getInstance();
+    final sharedPreferences = SharedPreferencesAsync();
     final settingsBloc = await _initSettingsBloc(sharedPreferences);
 
     return Dependencies(
@@ -75,7 +75,7 @@ final class CompositionRoot {
     return errorTrackingManager;
   }
 
-  Future<SettingsBloc> _initSettingsBloc(SharedPreferences prefs) async {
+  Future<SettingsBloc> _initSettingsBloc(SharedPreferencesAsync prefs) async {
     final localeRepository = LocaleRepositoryImpl(
       localeDataSource: LocaleDataSourceLocal(sharedPreferences: prefs),
     );

--- a/lib/src/feature/settings/data/locale_datasource.dart
+++ b/lib/src/feature/settings/data/locale_datasource.dart
@@ -23,9 +23,11 @@ final class LocaleDataSourceLocal extends PreferencesDao implements LocaleDataSo
   PreferencesEntry<String> get _languageCode => stringEntry(
         'settings.locale.languageCode',
       );
+
   PreferencesEntry<String> get _scriptCode => stringEntry(
         'settings.locale.scriptCode',
       );
+
   PreferencesEntry<String> get _countryCode => stringEntry(
         'settings.locale.countryCode',
       );
@@ -46,9 +48,9 @@ final class LocaleDataSourceLocal extends PreferencesDao implements LocaleDataSo
 
   @override
   Future<Locale?> getLocale() async {
-    final languageCode = _languageCode.read();
-    final scriptCode = _scriptCode.read();
-    final countryCode = _countryCode.read();
+    final languageCode = await _languageCode.read();
+    final scriptCode = await _scriptCode.read();
+    final countryCode = await _countryCode.read();
 
     if (languageCode == null) return null;
 

--- a/lib/src/feature/settings/data/theme_datasource.dart
+++ b/lib/src/feature/settings/data/theme_datasource.dart
@@ -41,9 +41,8 @@ final class ThemeDataSourceLocal extends PreferencesDao implements ThemeDataSour
 
   @override
   Future<AppTheme?> getTheme() async {
-    final seedColor = _seedColor.read();
-
-    final type = _themeMode.read();
+    final seedColor = await _seedColor.read();
+    final type = await _themeMode.read();
 
     if (type == null || seedColor == null) return null;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   cupertino_http: ^1.5.0
 
   # Persisting
-  shared_preferences: ^2.2.2
+  shared_preferences: ^2.3.2
   drift: ^2.13.1
   sqlite3_flutter_libs: ^0.5.18
 


### PR DESCRIPTION
Starting with version 2.3.0 there are three available APIs that can be used in this package. [SharedPreferences] is a legacy API that will be deprecated in the future. We highly encourage any new users of the plugin to use the newer [SharedPreferencesAsync] or [SharedPreferencesWithCache] APIs instead.
https://pub.dev/packages/shared_preferences#sharedpreferences-vs-sharedpreferencesasync-vs-sharedpreferenceswithcache