### PR TITLE
Handle negative string limits

### DIFF
--- a/app/lib/src/core/common/extensions/string_extension.dart
+++ b/app/lib/src/core/common/extensions/string_extension.dart
@@ -1,5 +1,10 @@
 /// Common extensions for [String]
 extension StringExtension on String {
   /// Returns a new string with the first [length] characters of this string.
-  String limit(int length) => length < this.length ? substring(0, length) : this;
+  ///
+  /// If [length] is negative the original string is returned. This prevents a
+  /// [RangeError] when calling [substring]. When [length] is zero an empty
+  /// string is returned.
+  String limit(int length) =>
+      length < 0 ? this : (length == 0 ? '' : (length < this.length ? substring(0, length) : this));
 }

--- a/app/test/src/core/common/extensions/string_extension_test.dart
+++ b/app/test/src/core/common/extensions/string_extension_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sizzle_starter/src/core/common/extensions/string_extension.dart';
+
+void main() {
+  group('StringExtension.limit', () {
+    const sample = 'Hello';
+
+    test('returns original string when length is negative', () {
+      expect(sample.limit(-1), sample);
+    });
+
+    test('returns empty string when length is zero', () {
+      expect(sample.limit(0), '');
+    });
+
+    test('returns substring when length is less than string length', () {
+      expect(sample.limit(2), 'He');
+    });
+
+    test('returns original string when length exceeds length', () {
+      expect(sample.limit(10), sample);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- return original string on negative `limit` values
- test string limit edge cases

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684047ac12508328ad574bb6876820c6