### PR TITLE
Fix: HTTP client initialization on Web by avoiding Cronet and Cupertino fallback

### DIFF
--- a/core/rest_client/lib/src/http/custom_client_browser.dart
+++ b/core/rest_client/lib/src/http/custom_client_browser.dart
@@ -1,0 +1,5 @@
+import 'package:http/http.dart' as http;
+
+http.Client? createCustomClient() {
+  return http.Client();
+}

--- a/core/rest_client/lib/src/http/custom_client_io.dart
+++ b/core/rest_client/lib/src/http/custom_client_io.dart
@@ -1,0 +1,17 @@
+import 'package:cronet_http/cronet_http.dart' show CronetClient;
+import 'package:cupertino_http/cupertino_http.dart' show CupertinoClient;
+import 'package:flutter/foundation.dart' show TargetPlatform, defaultTargetPlatform;
+import 'package:http/http.dart' as http;
+
+/// Creates an [http.Client] based on the current platform.
+///
+/// For Android, it returns a [CronetClient] with the default Cronet engine.
+/// For iOS and macOS, it returns a [CupertinoClient]
+/// with the default session configuration.
+http.Client? createCustomClient() {
+  return switch (defaultTargetPlatform) {
+    TargetPlatform.android => CronetClient.defaultCronetEngine(),
+    TargetPlatform.iOS || TargetPlatform.macOS => CupertinoClient.defaultSessionConfiguration(),
+    _ => null,
+  };
+}

--- a/core/rest_client/lib/src/http/rest_client_http.dart
+++ b/core/rest_client/lib/src/http/rest_client_http.dart
@@ -1,10 +1,9 @@
 import 'dart:async';
-
-import 'package:cronet_http/cronet_http.dart' show CronetClient;
-import 'package:cupertino_http/cupertino_http.dart' show CupertinoClient;
-import 'package:flutter/foundation.dart' show TargetPlatform, defaultTargetPlatform;
+import 'package:flutter/foundation.dart' show defaultTargetPlatform;
 import 'package:http/http.dart' as http;
 import 'package:rest_client/rest_client.dart';
+import 'package:rest_client/src/http/custom_client_io.dart'
+    if (dart.library.js_interop) 'package:rest_client/src/http/custom_client_browser.dart';
 import 'package:rest_client/src/http/check_exception_io.dart'
     if (dart.library.js_interop) 'package:rest_client/src/http/check_exception_browser.dart';
 
@@ -19,11 +18,7 @@ http.Client createDefaultHttpClient() {
   final platform = defaultTargetPlatform;
 
   try {
-    client = switch (platform) {
-      TargetPlatform.android => CronetClient.defaultCronetEngine(),
-      TargetPlatform.iOS || TargetPlatform.macOS => CupertinoClient.defaultSessionConfiguration(),
-      _ => null,
-    };
+    client = createCustomClient();
   } on Object catch (e, stackTrace) {
     Zone.current.print(
       'Failed to create a default http client for platform $platform $e $stackTrace',


### PR DESCRIPTION
This PR introduces a platform-aware http.Client factory to improve HTTP performance and behavior based on the underlying platform on issue #430 .

Changes made:
•	Added createCustomClient() to return a specialized http.Client.
•	Updated createDefaultHttpClient() to fallback to http.Client() if platform-specific creation fails.
•	Conditional imports are used to keep the implementation cross-platform (including Web).