### PR TITLE
Add PowerShell equivalent of bash scripts

### DIFF
--- a/scripts/ps/README-PowerShell.md
+++ b/scripts/ps/README-PowerShell.md
@@ -1,0 +1,58 @@
+# PowerShell Scripts for Windows
+
+This directory contains PowerShell equivalents of the bash scripts for Windows users.
+
+## Scripts Available
+
+- **`bootstrap.ps1`** - Gets Flutter dependencies and runs code generation for all packages with build_runner
+- **`analyze.ps1`** - Runs Flutter analyze on the entire project
+- **`clean.ps1`** - Cleans the workspace and all packages
+- **`format.ps1`** - Formats all Dart code in the project (excluding generated files)
+- **`test.ps1`** - Runs tests in all packages that have test directories
+
+## Usage
+
+Run any script from the project root using PowerShell:
+
+```powershell
+# Bootstrap the project (get dependencies and generate code)
+powershell -ExecutionPolicy Bypass -File "scripts\ps\bootstrap.ps1"
+
+# Analyze code
+powershell -ExecutionPolicy Bypass -File "scripts\ps\analyze.ps1"
+
+# Clean project
+powershell -ExecutionPolicy Bypass -File "scripts\ps\clean.ps1"
+
+# Format code
+powershell -ExecutionPolicy Bypass -File "scripts\ps\format.ps1"
+
+# Run tests
+powershell -ExecutionPolicy Bypass -File "scripts\ps\test.ps1"
+```
+
+## Alternative: Using pwsh (PowerShell Core)
+
+If you have PowerShell Core installed, you can run the scripts directly:
+
+```powershell
+# Make scripts executable (one time setup)
+pwsh -c "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser"
+
+# Run scripts directly
+pwsh scripts\ps\bootstrap.ps1
+pwsh scripts\ps\analyze.ps1
+pwsh scripts\ps\clean.ps1
+pwsh scripts\ps\format.ps1
+pwsh scripts\ps\test.ps1
+```
+
+## VS Code Tasks
+
+You can also use the predefined VS Code tasks instead of running scripts manually:
+- "Get dependencies" - equivalent to bootstrap (dependencies only)
+- "Run codegen" - runs code generation
+- "Format" - formats code
+- "Run tests" - runs tests
+
+Access these through VS Code's Command Palette (`Ctrl+Shift+P`) → "Tasks: Run Task"

--- a/scripts/ps/analyze.ps1
+++ b/scripts/ps/analyze.ps1
@@ -1,0 +1,5 @@
+#!/usr/bin/env pwsh
+# PowerShell analyze script for Sizzle Starter
+
+Write-Host "Running Flutter analyze..." -ForegroundColor Green
+flutter analyze . --no-pub

--- a/scripts/ps/bootstrap.ps1
+++ b/scripts/ps/bootstrap.ps1
@@ -1,0 +1,33 @@
+#!/usr/bin/env pwsh
+# PowerShell bootstrap script for Sizzle Starter
+# Get workspace dependencies
+
+Write-Host "Getting Flutter dependencies..." -ForegroundColor Green
+flutter pub get
+
+# For each package that has a pubspec.yaml file and build_runner dependency
+# run generation
+Write-Host "Finding packages with build_runner dependency..." -ForegroundColor Green
+
+Get-ChildItem -Path . -Recurse -Name "pubspec.yaml" | ForEach-Object {
+    $pubspecPath = $_
+    $dir = Split-Path $pubspecPath -Parent
+    
+    # Check if pubspec.yaml contains build_runner
+    $content = Get-Content $pubspecPath -Raw
+    if ($content -match "build_runner") {
+        Write-Host "`nGenerating files for $dir" -ForegroundColor Yellow
+        Push-Location $dir
+        try {
+            dart run build_runner build -d
+        }
+        catch {
+            Write-Host "Error running build_runner in $dir : $($_.Exception.Message)" -ForegroundColor Red
+        }
+        finally {
+            Pop-Location
+        }
+    }
+}
+
+Write-Host "`nBootstrap completed!" -ForegroundColor Green

--- a/scripts/ps/clean.ps1
+++ b/scripts/ps/clean.ps1
@@ -1,0 +1,27 @@
+#!/usr/bin/env pwsh
+# PowerShell clean script for Sizzle Starter
+
+Write-Host "Cleaning workspace..." -ForegroundColor Green
+flutter clean
+
+Write-Host "Cleaning packages..." -ForegroundColor Green
+
+# Clean packages in core and feature directories
+@("core", "feature") | ForEach-Object {
+    $dir = $_
+    if (Test-Path "$dir\pubspec.yaml") {
+        Write-Host "Cleaning $dir" -ForegroundColor Yellow
+        Push-Location $dir
+        try {
+            flutter clean
+        }
+        catch {
+            Write-Host "Error cleaning $dir : $($_.Exception.Message)" -ForegroundColor Red
+        }
+        finally {
+            Pop-Location
+        }
+    }
+}
+
+Write-Host "Clean completed!" -ForegroundColor Green

--- a/scripts/ps/format.ps1
+++ b/scripts/ps/format.ps1
@@ -1,0 +1,50 @@
+#!/usr/bin/env pwsh
+# PowerShell format script for Sizzle Starter
+
+Write-Host "Formatting Dart code..." -ForegroundColor Green
+
+# Run dart format in all packages of the project that have a pubspec.yaml file
+@("app", "core", "feature") | ForEach-Object {
+    $baseDir = $_
+    if (Test-Path $baseDir) {
+        Get-ChildItem -Path $baseDir -Recurse -Name "pubspec.yaml" | ForEach-Object {
+            $pubspecPath = $_
+            $dir = Split-Path $pubspecPath -Parent
+            
+            if (Test-Path "$dir\pubspec.yaml") {
+                Write-Host "`nFormatting $dir" -ForegroundColor Yellow
+                Push-Location $dir
+                try {
+                    $targets = @()
+                    @("lib", "test") | ForEach-Object {
+                        if (Test-Path $_) {
+                            $targets += $_
+                        }
+                    }
+                    
+                    if ($targets.Count -gt 0) {
+                        # Find all .dart files that are not generated files (don't contain .*.dart pattern)
+                        $dartFiles = @()
+                        foreach ($target in $targets) {
+                            $files = Get-ChildItem -Path $target -Recurse -Filter "*.dart" | 
+                                     Where-Object { $_.Name -notmatch '\..+\.dart$' }
+                            $dartFiles += $files.FullName
+                        }
+                        
+                        if ($dartFiles.Count -gt 0) {
+                            dart format --line-length 100 $dartFiles
+                        }
+                    }
+                }
+                catch {
+                    Write-Host "Error formatting $dir : $($_.Exception.Message)" -ForegroundColor Red
+                }
+                finally {
+                    Pop-Location
+                }
+            }
+        }
+    }
+}
+
+Write-Host "`nFormatting completed!" -ForegroundColor Green

--- a/scripts/ps/test.ps1
+++ b/scripts/ps/test.ps1
@@ -1,0 +1,36 @@
+#!/usr/bin/env pwsh
+# PowerShell test script for Sizzle Starter
+
+# Enable error handling
+$ErrorActionPreference = "Stop"
+
+Write-Host "Finding test directories..." -ForegroundColor Green
+
+# Find directories with a pubspec.yaml and a test/ folder
+$testDirs = @()
+
+Get-ChildItem -Path . -Recurse -Name "pubspec.yaml" | ForEach-Object {
+    $pubspecPath = $_
+    $dir = Split-Path $pubspecPath -Parent
+    
+    if (Test-Path "$dir\test") {
+        $testDirs += $dir
+        Write-Host "Found test directory: $dir" -ForegroundColor Yellow
+    }
+}
+
+if ($testDirs.Count -gt 0) {
+    Write-Host "`nRunning tests in found directories..." -ForegroundColor Green
+    
+    # Create reports directory if it doesn't exist
+    if (-not (Test-Path "reports")) {
+        New-Item -ItemType Directory -Path "reports" | Out-Null
+    }
+    
+    # Run flutter test with all test directories
+    flutter test $testDirs --no-pub --coverage --file-reporter json:reports/tests.json
+    
+    Write-Host "`nTests completed!" -ForegroundColor Green
+} else {
+    Write-Host "No directories with pubspec.yaml and test/ folder found." -ForegroundColor Yellow
+}


### PR DESCRIPTION
## Add PowerShell Scripts for Windows Users

### Problem
The existing bash scripts in scripts folder cannot be executed on Windows without WSL, and I did encounter WSL configuration issues when trying to run `bash scripts/bootstrap.bash`.

### Solution
Created PowerShell equivalents of all bash scripts 

### Usage
Windows users can now run:
```powershell
powershell -ExecutionPolicy Bypass -File "scripts\ps\bootstrap.ps1"
```